### PR TITLE
Feat: "Feat comment athentication"

### DIFF
--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/controller/CommentController.kt
@@ -5,11 +5,12 @@ import com.teamsparta.bunnies.domain.comment.dto.CreateCommentRequestDto
 import com.teamsparta.bunnies.domain.comment.dto.UpdateCommentRequestDto
 import com.teamsparta.bunnies.domain.comment.service.CommentService
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
-
+@Tag(name = "comments", description = "댓글 API")
 @RequestMapping("/api/posts/{postId}/comments")
 @RestController
 class CommentController(

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/controller/CommentController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "comments", description = "댓글 API")
@@ -16,6 +17,8 @@ import org.springframework.web.bind.annotation.*
 class CommentController(
         val commentService: CommentService
 ) {
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
     @Operation(summary = "comment 생성")
     @PostMapping
     fun createComment(
@@ -39,6 +42,7 @@ class CommentController(
                 .status(HttpStatus.OK)
                 .body(commentService.updateComment(postId, commentId, updateCommentRequestDto))
     }
+
 
     @Operation(summary = "comment 삭제")
     @DeleteMapping("/{commentId}")

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/controller/CommentController.kt
@@ -4,11 +4,13 @@ import com.teamsparta.bunnies.domain.comment.dto.CommentResponseDto
 import com.teamsparta.bunnies.domain.comment.dto.CreateCommentRequestDto
 import com.teamsparta.bunnies.domain.comment.dto.UpdateCommentRequestDto
 import com.teamsparta.bunnies.domain.comment.service.CommentService
+import com.teamsparta.bunnies.infra.security.UserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "comments", description = "댓글 API")
@@ -24,10 +26,11 @@ class CommentController(
     fun createComment(
         @PathVariable postId: Long,
         @RequestBody createCommentRequestDto: CreateCommentRequestDto,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
     ): ResponseEntity<CommentResponseDto> {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(commentService.createComment(createCommentRequestDto, postId))
+                .body(commentService.createComment(createCommentRequestDto, postId, userPrincipal))
     }
 
     @Operation(summary = "comment 수정")

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/controller/CommentController.kt
@@ -54,9 +54,10 @@ class CommentController(
     fun deleteComment(
         @PathVariable postId: Long,
         @PathVariable commentId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
     ): ResponseEntity<Unit> {
 
-        commentService.deleteComment(commentId)
+        commentService.deleteComment(commentId, userPrincipal)
 
         return ResponseEntity
             .status(HttpStatus.NO_CONTENT)

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/controller/CommentController.kt
@@ -33,17 +33,19 @@ class CommentController(
                 .body(commentService.createComment(createCommentRequestDto, postId, userPrincipal))
     }
 
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
     @Operation(summary = "comment 수정")
     @PutMapping("/{commentId}")
     fun updateComment(
         @PathVariable postId: Long,
         @PathVariable commentId: Long,
-        @RequestBody updateCommentRequestDto: UpdateCommentRequestDto
+        @RequestBody updateCommentRequestDto: UpdateCommentRequestDto,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
     ): ResponseEntity<CommentResponseDto> {
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(commentService.updateComment(postId, commentId, updateCommentRequestDto))
+                .body(commentService.updateComment(postId, commentId, updateCommentRequestDto, userPrincipal))
     }
 
 

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/model/CommentEntity.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/model/CommentEntity.kt
@@ -15,8 +15,8 @@ class Comment(
         @Column(name = "comment")
         var comment: String,
 
-  //      @Column(name = "name")
-    //    var name: String,
+        @Column(name = "user_id")
+        var userId: Long,
 
         @ManyToOne(fetch = FetchType.LAZY)// JPA(Java Persistence API)에서 "Basic" 타입으로 지정된 필드에 대해 "Persistence Entity"사용불가
         @JoinColumn(name = "postId")

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentService.kt
@@ -7,6 +7,6 @@ import com.teamsparta.bunnies.infra.security.UserPrincipal
 
 interface CommentService {
     fun createComment(request: CreateCommentRequestDto, postId: Long, userPrincipal: UserPrincipal): CommentResponseDto
-    fun updateComment(postId: Long, commentId: Long, request: UpdateCommentRequestDto): CommentResponseDto
+    fun updateComment(postId: Long, commentId: Long, request: UpdateCommentRequestDto, userPrincipal: UserPrincipal): CommentResponseDto
     fun deleteComment(commentId:Long)
 }

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentService.kt
@@ -3,9 +3,10 @@ package com.teamsparta.bunnies.domain.comment.service
 import com.teamsparta.bunnies.domain.comment.dto.CommentResponseDto
 import com.teamsparta.bunnies.domain.comment.dto.CreateCommentRequestDto
 import com.teamsparta.bunnies.domain.comment.dto.UpdateCommentRequestDto
+import com.teamsparta.bunnies.infra.security.UserPrincipal
 
 interface CommentService {
-    fun createComment(request: CreateCommentRequestDto, postId: Long): CommentResponseDto
+    fun createComment(request: CreateCommentRequestDto, postId: Long, userPrincipal: UserPrincipal): CommentResponseDto
     fun updateComment(postId: Long, commentId: Long, request: UpdateCommentRequestDto): CommentResponseDto
     fun deleteComment(commentId:Long)
 }

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentService.kt
@@ -8,5 +8,5 @@ import com.teamsparta.bunnies.infra.security.UserPrincipal
 interface CommentService {
     fun createComment(request: CreateCommentRequestDto, postId: Long, userPrincipal: UserPrincipal): CommentResponseDto
     fun updateComment(postId: Long, commentId: Long, request: UpdateCommentRequestDto, userPrincipal: UserPrincipal): CommentResponseDto
-    fun deleteComment(commentId:Long)
+    fun deleteComment(commentId:Long, userPrincipal: UserPrincipal)
 }

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentServiceImpl.kt
@@ -7,6 +7,7 @@ import com.teamsparta.bunnies.domain.comment.dto.UpdateCommentRequestDto
 import com.teamsparta.bunnies.domain.comment.model.Comment
 import com.teamsparta.bunnies.domain.comment.model.toResponse
 import com.teamsparta.bunnies.domain.comment.repository.CommentRepository
+import com.teamsparta.bunnies.domain.exception.InvalidCredentialException
 import com.teamsparta.bunnies.domain.exception.ModelNotFoundException
 import com.teamsparta.bunnies.domain.post.repository.PostRepository
 import com.teamsparta.bunnies.infra.security.UserPrincipal
@@ -48,10 +49,17 @@ class CommentServiceImpl(
     override fun updateComment(
         postId: Long,
         commentId: Long,
-        request: UpdateCommentRequestDto
+        request: UpdateCommentRequestDto,
+        userPrincipal: UserPrincipal
     ): CommentResponseDto {
         val foundComment = commentId.let { commentRepository.findByIdOrNull(it) }
                 ?: throw ModelNotFoundException("Comment", commentId)
+
+        //role이 USER이면서 본인이 아닐 경우에 권한 없음 예외처리
+        if ((userPrincipal.id != foundComment.userId) && (userPrincipal.authorities.first().toString() == "ROLE_USER"))
+            throw InvalidCredentialException("본인의 글이 아니므로 권한이 없습니다.")
+
+
         // 찾아온 댓글이 작성자의 것인지 확인합니다.
 //        foundComment.checkAuthentication(request.name)
         // 요청에서 받아온 새로운 댓글 내용으로 댓글을 수정합니다.

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentServiceImpl.kt
@@ -73,11 +73,17 @@ class CommentServiceImpl(
     @Transactional
     //댓글삭제.id 를 통해 댓글 호출,null일때 예외
     override fun deleteComment(
-        commentId:Long
+        commentId:Long,
+        userPrincipal: UserPrincipal
     ) {
         val foundComment = commentId.let {
             commentRepository.findByIdOrNull(it)
         } ?: throw ModelNotFoundException("Comment", commentId)
+
+        //role이 USER이면서 본인이 아닐 경우에 권한 없음 예외처리
+        if ((userPrincipal.id != foundComment.userId) && (userPrincipal.authorities.first().toString() == "ROLE_USER"))
+            throw InvalidCredentialException("본인의 글이 아니므로 권한이 없습니다.")
+
 // 댓글 작성자인지 확인
 //        foundComment.checkAuthentication(request.name)
 //해당하는 댓글의 ID를 사용하여 데이터베이스에서 해당 댓글을 삭제

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/comment/service/CommentServiceImpl.kt
@@ -9,6 +9,7 @@ import com.teamsparta.bunnies.domain.comment.model.toResponse
 import com.teamsparta.bunnies.domain.comment.repository.CommentRepository
 import com.teamsparta.bunnies.domain.exception.ModelNotFoundException
 import com.teamsparta.bunnies.domain.post.repository.PostRepository
+import com.teamsparta.bunnies.infra.security.UserPrincipal
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,7 +22,11 @@ class CommentServiceImpl(
 ) : CommentService {
 
     @Transactional
-    override fun createComment(request: CreateCommentRequestDto, postId: Long): CommentResponseDto {
+    override fun createComment(
+        request: CreateCommentRequestDto,
+        postId: Long,
+        userPrincipal: UserPrincipal
+    ): CommentResponseDto {
 
         // 게시글을 찾아오고, 없으면 예외를 던집니다.
              val targetPost = postRepository.findByIdOrNull(postId)
@@ -30,7 +35,7 @@ class CommentServiceImpl(
         val comment = Comment(
                post = targetPost,
                comment = request.comment,
-//               name = request.name
+               userId = userPrincipal.id
          )
         // 댓글을 저장합니다.
            commentRepository.save(comment)

--- a/src/main/kotlin/com/teamsparta/bunnies/domain/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/bunnies/domain/post/service/PostServiceImpl.kt
@@ -66,7 +66,7 @@ class PostServiceImpl(
 
         // ADMIN 또는 본인인 경우에만 수정 가능하도록 확인
         if ((userPrincipal.id != post.userId) && (userPrincipal.authorities.first().toString() == "ROLE_USER"))
-            throw InvalidCredentialException("권한이 없습니다.")
+            throw InvalidCredentialException("본인의 글이 아니므로 권한이 없습니다.")
 
         return post
             .apply { update(updatePostDto) }
@@ -83,7 +83,7 @@ class PostServiceImpl(
 
         // role이 ADMIN이거나 본인인 경우에만 수정 가능하도록 확인
         if ((userPrincipal.id != post.userId) && (userPrincipal.authorities.first().toString() == "ROLE_USER"))
-            throw InvalidCredentialException("권한이 없습니다.")
+            throw InvalidCredentialException("본인의 글이 아니므로 권한이 없습니다.")
 
         return post
             .apply { isComplete() }
@@ -100,7 +100,7 @@ class PostServiceImpl(
 
         // role이 ADMIN이거나 본인인 경우에만 삭제 가능하도록 확인
         if ((userPrincipal.id != post.userId) && (userPrincipal.authorities.first().toString() == "ROLE_USER"))
-            throw InvalidCredentialException("권한이 없습니다.")
+            throw InvalidCredentialException("본인의 글이 아니므로 권한이 없습니다.")
 
         postRepository.delete(post)
     }


### PR DESCRIPTION
1. comment 생성, 수정, 삭제의 인증을 추가했습니다.
2. post 권한 메세지를 수정했습니다. (권한이 없습니다 -> 본인의 글이 아니므로 권한이 없습니다.)

3. 아래 테스트 모두 완료했습니다.
- 로그인 한 상태에서만 댓글을 생성, 수정 삭제 할 수 있음 확인
- 본인의 글이 아닐 땐 댓글의 수정, 삭제 할 수 없음 확인
- 관리자는 모든 댓글을 수정, 삭제 할 수 있음 확인
- 단, comment DB에 user id가 null 로 저장된 댓글 일 경우에 아무것도 안됨 -> null로 된 DB는 없애야 할 것 같습니다.

Ref: #4